### PR TITLE
메인 페이지 추가

### DIFF
--- a/src/components/button.css
+++ b/src/components/button.css
@@ -1,5 +1,5 @@
 .login-button {
-	position: relative;
+	position: absolute;
 	top: 310px;
 	left: 50%;
 	transform: translateX(-50%);
@@ -7,6 +7,7 @@
 	height: 45px;
 	background: #4969e0;
 	border-radius: 10px;
+
 	color: white;
 	font-weight: 500;
 	font-size: 14px;
@@ -14,6 +15,42 @@
 }
 
 .login-button.disabled {
-	background-color: ##e5bcbc;
+	background-color: #e5bcbc;
 	cursor: not-allowed;
+}
+
+.rental-button {
+	position: absolute;
+	width: 97px;
+	height: 103px;
+	left: calc(50% - 97px / 2 - 61.5px);
+	top: calc(50% - 103px / 2 - 50.5px);
+	background: #ffffff;
+	border: 2px solid #d9d9d9;
+	border-radius: 10px;
+
+	font-family: 'Noto Sans KR';
+	font-style: normal;
+	font-weight: 500;
+	font-size: 20px;
+	line-height: 24px;
+	color: #2e5bff;
+}
+
+.return-button {
+	position: absolute;
+	width: 97px;
+	height: 103px;
+	left: calc(50% - 97px / 2 + 61.5px);
+	top: calc(50% - 103px / 2 - 50.5px);
+	background: #ffffff;
+	border: 2px solid #d9d9d9;
+	border-radius: 10px;
+
+	font-family: 'Noto Sans KR';
+	font-style: normal;
+	font-weight: 500;
+	font-size: 20px;
+	line-height: 24px;
+	color: #2e5bff;
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,12 @@
 import { Routes, Route } from 'react-router-dom';
 import LoginPage from '@/pages/login/login-page';
+import MainPage from '@/pages/main/main-page';
 
 function Main() {
 	return (
 		<Routes>
 			<Route path="/" element={<LoginPage />} />
+			<Route path="/main" element={<MainPage />} />
 		</Routes>
 	);
 }

--- a/src/pages/login/login-form.jsx
+++ b/src/pages/login/login-form.jsx
@@ -6,8 +6,10 @@ import Button from '@/components/button';
 import Message from '../../components/message';
 import { use_login_limiter } from '@/hooks/use-login-limiter';
 import './login.css';
+import { useNavigate } from 'react-router-dom';
 
 function LoginForm() {
+	const navigate = useNavigate();
 	const [user_id, set_user_id] = useState('');
 	const [pwd, set_pwd] = useState('');
 	const [message, set_message] = useState('');
@@ -42,18 +44,15 @@ function LoginForm() {
 					lock_temporarily();
 					return;
 				}
-				set_error(
-					ERROR_MESSAGES.invalid_login.replace(
-						'{count}',
-						3 - attempts
-					)
-				);
+				set_error(ERROR_MESSAGES.invalid_login.replace('{count}', 3 - attempts));
 				return;
 			}
 
 			set_message(SUCCESS_MESSAGES.login_success);
 			set_attempts(0);
 			console.log('sToken:', match[1]);
+
+			navigate('/main');
 		} catch (err) {
 			set_error(`${ERROR_MESSAGES.login_fail}: ${err.message}`);
 		}
@@ -62,10 +61,7 @@ function LoginForm() {
 	const render_lock_message = () => {
 		if (!is_locked || !remaining_time) return null;
 
-		const msg = INFO_MESSAGES.too_many_attempts.replace(
-			'{time}',
-			remaining_time.toString()
-		);
+		const msg = INFO_MESSAGES.too_many_attempts.replace('{time}', remaining_time.toString());
 
 		return <Message type="info" text={msg} />;
 	};

--- a/src/pages/main/main-form.jsx
+++ b/src/pages/main/main-form.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Button from '@/components/button';
+import './main.css';
+import { useNavigate } from 'react-router-dom';
+
+function MainForm() {
+	const navigate = useNavigate();
+
+	return (
+		<div className="main-page">
+			<Button onClick={() => navigate('/')} class_name="rental-button">
+				대여
+			</Button>
+			<Button onClick={() => navigate('/')} class_name="return-button">
+				반납
+			</Button>
+			<Button onClick={() => navigate('/')} class_name="login-button">
+				로그아웃
+			</Button>
+		</div>
+	);
+}
+
+export default MainForm;

--- a/src/pages/main/main-page.jsx
+++ b/src/pages/main/main-page.jsx
@@ -1,0 +1,14 @@
+import MainForm from './main-form';
+import './main.css';
+
+function MainPage() {
+	return (
+		<div className="main-container">
+			<div className="title">SCLibrary</div>
+			<div className="label">환영합니다</div>
+			<MainForm />
+		</div>
+	);
+}
+
+export default MainPage;

--- a/src/pages/main/main.css
+++ b/src/pages/main/main.css
@@ -1,0 +1,31 @@
+.main-container {
+	position: relative;
+	top: 40px;
+	width: 400px;
+	height: 600px;
+	margin: 0 auto;
+	background: #fff;
+	border: 2px solid #2e5bff;
+	border-radius: 20px;
+	box-sizing: border-box;
+	font-family: 'Noto Sans KR', sans-serif;
+}
+
+.title {
+	position: absolute;
+	top: 80px;
+	left: 50%;
+	transform: translateX(-50%);
+	font-weight: 700;
+	font-size: 32px;
+	color: #2e5bff;
+}
+
+.label {
+	position: absolute;
+	top: 150px;
+	left: 50%;
+	transform: translateX(-50%);
+	font-size: 12px;
+	color: #8fa7ff;
+}


### PR DESCRIPTION
#1
- 메인 페이지 UI 레이아웃 구현
- [대여하기], [반납하기], [로그아웃] 버튼 구성
- 로그아웃 시 로그인 페이지('/')로 리다이렉트 처리
- 대여/반납 버튼 클릭 시 각 컴포넌트 페이지로 이동
  (컴포넌트 뼈대만 구현, 추후 기능 연결 예정)