### PR TITLE
Qrcode 인식 페이지 구현

### DIFF
--- a/src/components/button.css
+++ b/src/components/button.css
@@ -14,6 +14,38 @@
 	border: none;
 }
 
+.main-button {
+	position: absolute;
+	top: 370px;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 220px;
+	height: 45px;
+	background: #4969e0;
+	border-radius: 10px;
+
+	color: white;
+	font-weight: 500;
+	font-size: 14px;
+	border: none;
+}
+
+.picture-button {
+	position: absolute;
+	top: 310px;
+	left: 50%;
+	transform: translateX(-50%);
+	width: 220px;
+	height: 45px;
+	background: #4969e0;
+	border-radius: 10px;
+
+	color: white;
+	font-weight: 500;
+	font-size: 14px;
+	border: none;
+}
+
 .login-button.disabled {
 	background-color: #e5bcbc;
 	cursor: not-allowed;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,14 @@
 import { Routes, Route } from 'react-router-dom';
 import LoginPage from '@/pages/login/login-page';
 import MainPage from '@/pages/main/main-page';
+import QRPage from '@/pages/qrscan/qr-page';
 
 function Main() {
 	return (
 		<Routes>
 			<Route path="/" element={<LoginPage />} />
 			<Route path="/main" element={<MainPage />} />
+			<Route path="/qrscan" element={<QRPage />} />
 		</Routes>
 	);
 }

--- a/src/pages/login/login-page.jsx
+++ b/src/pages/login/login-page.jsx
@@ -3,10 +3,12 @@ import './login.css';
 
 function LoginPage() {
 	return (
-		<div className="login-container">
-			<div className="title">SCLibrary</div>
-			<div className="label">유세인트 계정을 입력하세요</div>
-			<LoginForm />
+		<div className="login-page">
+			<div className="login-container">
+				<div className="title">SCLibrary</div>
+				<div className="label">유세인트 계정을 입력하세요</div>
+				<LoginForm />
+			</div>
 		</div>
 	);
 }

--- a/src/pages/main/main-form.jsx
+++ b/src/pages/main/main-form.jsx
@@ -9,13 +9,13 @@ function MainForm() {
 	return (
 		<div className="main-page">
 			<Button
-				onClick={() => navigate('/rental', { state: { mode: 'rental' } })}
+				onClick={() => navigate('/qrscan', { state: { mode: 'rental' } })}
 				class_name="rental-button"
 			>
 				대여
 			</Button>
 			<Button
-				onClick={() => navigate('/return', { state: { mode: 'return' } })}
+				onClick={() => navigate('/qrscan', { state: { mode: 'return' } })}
 				class_name="return-button"
 			>
 				반납

--- a/src/pages/main/main-form.jsx
+++ b/src/pages/main/main-form.jsx
@@ -8,10 +8,16 @@ function MainForm() {
 
 	return (
 		<div className="main-page">
-			<Button onClick={() => navigate('/')} class_name="rental-button">
+			<Button
+				onClick={() => navigate('/rental', { state: { mode: 'rental' } })}
+				class_name="rental-button"
+			>
 				대여
 			</Button>
-			<Button onClick={() => navigate('/')} class_name="return-button">
+			<Button
+				onClick={() => navigate('/return', { state: { mode: 'return' } })}
+				class_name="return-button"
+			>
 				반납
 			</Button>
 			<Button onClick={() => navigate('/')} class_name="login-button">

--- a/src/pages/main/main-page.jsx
+++ b/src/pages/main/main-page.jsx
@@ -3,10 +3,12 @@ import './main.css';
 
 function MainPage() {
 	return (
-		<div className="main-container">
-			<div className="title">SCLibrary</div>
-			<div className="label">환영합니다</div>
-			<MainForm />
+		<div className="main-page">
+			<div className="main-container">
+				<div className="title">SCLibrary</div>
+				<div className="label">환영합니다</div>
+				<MainForm />
+			</div>
 		</div>
 	);
 }

--- a/src/pages/qrscan/qr-form.jsx
+++ b/src/pages/qrscan/qr-form.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import Button from '@/components/button';
+import './qrscan.css';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+function QRForm() {
+	const navigate = useNavigate();
+	const location = useLocation();
+	const { mode } = location.state || {};
+
+	const handle_qr_success = () => {
+		if (mode == 'rental') {
+			navigate('/main');
+		} else if (mode == 'return') {
+			navigate('/');
+		} else {
+			console.error('잘못된 접근');
+		}
+	};
+
+	return (
+		<div>
+			<Button onClick={handle_qr_success} class_name="picture-button">
+				촬영
+			</Button>
+			<Button onClick={() => navigate('/main')} class_name="main-button">
+				홈으로
+			</Button>
+		</div>
+	);
+}
+
+export default QRForm;

--- a/src/pages/qrscan/qr-page.jsx
+++ b/src/pages/qrscan/qr-page.jsx
@@ -1,0 +1,16 @@
+import QRForm from './qr-form';
+import './qrscan.css';
+
+function QRPage() {
+	return (
+		<div className="qrscan-page">
+			<div className="qrscan-container">
+				<div className="qrscan-title">QR 코드 인식</div>
+				<div className="qrscan-label">카메라에서 10~15cm 떨어져 인식시켜주세요</div>
+				<QRForm />
+			</div>
+		</div>
+	);
+}
+
+export default QRPage;

--- a/src/pages/qrscan/qrscan.css
+++ b/src/pages/qrscan/qrscan.css
@@ -1,0 +1,44 @@
+.qrscan-container {
+	position: relative;
+	top: 40px;
+	width: 400px;
+	height: 600px;
+	margin: 0 auto;
+	background: #fff;
+	border: 2px solid #2e5bff;
+	border-radius: 20px;
+	box-sizing: border-box;
+	font-family: 'Noto Sans KR', sans-serif;
+}
+
+.qrscan-title {
+	position: absolute;
+	width: 300px;
+	height: 38px;
+	left: calc(50% - 200px / 2);
+	top: calc(50% - 38px / 2 - 160px);
+
+	font-family: 'Noto Sans KR';
+	font-style: normal;
+	font-weight: 700;
+	font-size: 32px;
+	line-height: 38px;
+
+	color: #003c9e;
+}
+
+.qrscan-label {
+	position: absolute;
+	width: 300px;
+	height: 17px;
+	left: calc(50% - 140px);
+	top: 230px;
+
+	font-family: 'Noto Sans KR';
+	font-style: normal;
+	font-weight: 500;
+	font-size: 14px;
+	line-height: 17px;
+
+	color: #000000;
+}


### PR DESCRIPTION
#3 📄 QR 스캔 페이지 레이아웃 및 페이지 분기 구조 구현

✅ 주요 구현 내용
- `/qr-scan` 경로에 QR 인식 페이지 (`QRPage`, `QRForm`) 생성
- 로그인/메인 페이지와 구조 일관성을 맞춰 `Page/Form` 분리
- `mode` state 값(rental/return)에 따라 navigate 분기 로직 구성
- 버튼 클릭 시 임시로 navigate 동작 (QR 인식 로직은 미구현)

🎨 UI 관련
- QR 페이지 전용 CSS 분리 (`qrscan.css`)
- 클래스명 고유화(`qrscan-` prefix)로 다른 페이지와 스타일 충돌 방지

⚠️ 미구현
- 실제 QR 카메라 연동 및 QR 성공 시 자동 navigate 처리
- QR 인식 실패/재시도 로직

🔧 이후 작업 계획
- QR 인식 기능 연동
- 인식 성공 시 rental/return 확인 페이지로 이동 처리
- 인식 실패 시 오류 메시지 및 재시도 버튼 구성