### PR TITLE
로그인 상태 localStorage 저장 및 로그아웃 기능 구현

### DIFF
--- a/src/pages/login/login-form.jsx
+++ b/src/pages/login/login-form.jsx
@@ -56,7 +56,8 @@ function LoginForm() {
 				const user = await verifyUserBySchoolNumber(user_id);
 				console.log('유저 확인됨:', user);
 				set_message(SUCCESS_MESSAGES.login_success);
-				navigate('/main', { state: { user } });
+				localStorage.setItem('user', JSON.stringify(user));
+				navigate('/main');
 			} catch (err) {
 				if (err.response?.status === 404) {
 					set_error(ERROR_MESSAGES.user_not_found || '등록되지 않은 유저입니다');

--- a/src/pages/login/login-page.jsx
+++ b/src/pages/login/login-page.jsx
@@ -1,7 +1,13 @@
 import LoginForm from './login-form';
 import './login.css';
+import { useEffect } from 'react';
 
 function LoginPage() {
+	useEffect(() => {
+		localStorage.removeItem('user');
+		console.log('로그아웃 처리');
+	}, []);
+
 	return (
 		<div className="login-page">
 			<div className="login-container">

--- a/src/pages/main/main-page.jsx
+++ b/src/pages/main/main-page.jsx
@@ -1,12 +1,12 @@
 import MainForm from './main-form';
 import './main.css';
 import { useLocation, useNavigate } from 'react-router-dom';
-/*import { useEffect } from 'react';
+import { useEffect } from 'react';
 
 function MainPage() {
 	const location = useLocation();
 	const navigate = useNavigate();
-	const user = location.state?.user;
+	const user = JSON.parse(localStorage.getItem('user'));
 
 	useEffect(() => {
 		if (!user) {
@@ -26,8 +26,8 @@ function MainPage() {
 			</div>
 		</div>
 	);
-}*/
-function MainPage() {
+}
+/*function MainPage() {
 	const location = useLocation();
 	const user = location.state?.user;
 
@@ -42,6 +42,6 @@ function MainPage() {
 			</div>
 		</div>
 	);
-}
+}*/
 
 export default MainPage;


### PR DESCRIPTION
 #9 로그인 정보 상태 유지 및 로그아웃 기능 구현

주요 변경 사항
- 로그인 성공 시 user 객체를 localStorage에 저장 (새로고침 유지용)
  → localStorage.setItem('user', JSON.stringify(user))
- 모든 페이지에서 localStorage에서 user 정보 가져와 활용 가능
  → JSON.parse(localStorage.getItem('user'))

로그아웃 처리
- '/' 경로(navigate('/') 또는 직접 진입) 시 자동으로 localStorage에서 user 삭제
  → LoginPage 진입 시 useEffect로 localStorage.removeItem('user') 실행
- 추후 로그아웃 버튼 클릭 시에도 navigate('/')만 호출하면 로그아웃 완료

사용자 흐름 개선
- navigate('/') 시 자동 로그아웃 → UX 흐름 자연스럽게 유지

추후 개선 예정
- 추후 서버 토큰 발급 시 localStorage에 토큰 저장 및 인증 헤더 적용 예정